### PR TITLE
Avoid : (colons) to be added to PATH

### DIFF
--- a/commands/terminal.js
+++ b/commands/terminal.js
@@ -272,7 +272,7 @@ module.exports = function(opts) {
 	server.put('/{id}', function(req, res) {
 		var id = req.params.id;
 		var deployed = new Date().toISOString();
-		var cwd = path.join('builds', id+'@'+deployed);
+		var cwd = path.join('builds', id+'@'+deployed).replace(/:/g, '-');
 
 		var onerror = function(status, message) {
 			log(id, 'build failed');


### PR DESCRIPTION
There was en error that `PATH` ended up looking like `PATH=/foo/bar:/../myservice@2014-01-01:01:01`.

This PR changed so that the previous example would be `PATH=/foo/bar:/../myservice@2014-01-01-01-01`
