### PR TITLE
added hostnames to info, ps and list output

### DIFF
--- a/commands/docks.js
+++ b/commands/docks.js
@@ -18,6 +18,7 @@ module.exports = function (remote, id, opts) {
         nodes: docks.list.reduce(function (acc, service) {
           var leaf = {}
           leaf.status = service.status
+          if (docks.hostname) leaf.hostname = docks.hostname
           leaf.cwd = service.cwd
 
           if (service.command)  leaf.command = service.command.join(' ')

--- a/commands/info.js
+++ b/commands/info.js
@@ -32,6 +32,7 @@ module.exports = function (remote, id, opts) {
         dock.list.filter(filter).forEach(function (current) {
           var info = {}
 
+          if (dock.hostname) info.hostname = dock.hostname
           if (current.status) info.status = current.status
           if (current.tags && current.tags.length) info.tags = current.tags.join(', ')
           if (current.started) info.started = relativeDate(current.started)

--- a/commands/ps.js
+++ b/commands/ps.js
@@ -23,9 +23,9 @@ module.exports = function (remote, id, opts) {
         node.label = proc.id
         node.leaf = leaf
 
+        if (dock.hostname) leaf.hostname = dock.hostname
         leaf.status = proc.status
         leaf.cwd = proc.cwd
-
         if (proc.command)  leaf.command = proc.command.join(' ')
         if (proc.revision) leaf.revision = proc.revision
         if (proc.pid)      leaf.pid = proc.pid

--- a/commands/run-dock.js
+++ b/commands/run-dock.js
@@ -38,6 +38,7 @@ module.exports = function (remote, opts) {
   var me = {
     type: 'dock',
     version: pkg.version,
+    hostname: os.hostname(),
     id: opts.id || os.hostname(),
     tags: tags,
     default: !!opts.default
@@ -229,7 +230,12 @@ module.exports = function (remote, opts) {
       var list = mons.list().map(function (mon) {
         return xtend(mon.toJSON(), {tags: db.get(mon.id).tags || []}, info[mon.id])
       })
-      cb(null, [{id: me.id, tags: me.tags, list: list}])
+      cb(null, [{
+        id: me.id,
+        hostname: me.hostname,
+        tags: me.tags,
+        list: list
+      }])
     })
 
     protocol.on('subscribe', function (id, cb) {


### PR DESCRIPTION
I've added hostname to hms info, hms ps, and hms docks. I am not 100% sure this is the correct approach.

(I kinda screwed up the remote branch settings when I cloned the repo and removed a semicolon, so here's a new pull request. It is really for the better, because now the added semicolon is forever gone :bike: :shed:)