### PR TITLE
Allow all commands to use the --key option.

### DIFF
--- a/commands/add.js
+++ b/commands/add.js
@@ -9,7 +9,7 @@ module.exports = function (remote, id, opts) {
   if (!id) return ui.error('Service name required')
   if (!opts.start && opts.start !== false) return ui.error(help)
 
-  var c = client(remote)
+  var c = client(remote, {key: opts.key})
   var unspin = ui.spin('Adding', id)
 
   updateable(id, {}, opts, function (err) {

--- a/commands/deploy.js
+++ b/commands/deploy.js
@@ -45,7 +45,7 @@ module.exports = function (remote, id, opts) {
     if (repo && repo !== process.cwd() && !opts.force) return ui.error('You are in a git repo but not at the root. Use --force to ignore')
 
     var ignore = opts.ignore === false ? noop : (ignoreFile.sync('.hmsignore') || ignoreFile.sync('.gitignore') || '')
-    var c = client(remote)
+    var c = client(remote, {key: opts.key})
 
     var tmp = path.join(os.tmpDir(), 'hms-' + id + '.tgz')
     var rev = typeof opts.revision === 'string' ? opts.revision : undefined

--- a/commands/docks.js
+++ b/commands/docks.js
@@ -3,7 +3,7 @@ var ui = require('../lib/ui')
 var relativeDate = require('relative-date')
 
 module.exports = function (remote, id, opts) {
-  var connection = client(remote)
+  var connection = client(remote, {key: opts.key})
 
   if (id) {
     connection.ps(function (err, docks) {

--- a/commands/info.js
+++ b/commands/info.js
@@ -9,7 +9,7 @@ module.exports = function (remote, id, opts) {
     return !id || proc.id === id
   }
 
-  var c = client(remote)
+  var c = client(remote, {key: opts.key})
 
   c.get(id, function (err, service) {
     if (err) return ui.error(err)

--- a/commands/log.js
+++ b/commands/log.js
@@ -3,7 +3,7 @@ var ui = require('../lib/ui')
 var logStream = require('../lib/log-stream')
 
 module.exports = function (remote, id, opts) {
-  var c = client(remote)
+  var c = client(remote, {key: opts.key})
 
   c.subscribe(id, function (err) {
     if (err) return ui.error(err)

--- a/commands/ps.js
+++ b/commands/ps.js
@@ -3,7 +3,7 @@ var client = require('../')
 var ui = require('../lib/ui')
 
 module.exports = function (remote, id, opts) {
-  var c = client(remote)
+  var c = client(remote, {key: opts.key})
 
   var filter = function (proc) {
     return !id || proc.id === id

--- a/commands/remove.js
+++ b/commands/remove.js
@@ -4,7 +4,7 @@ var ui = require('../lib/ui')
 module.exports = function (remote, id, opts) {
   if (!id) return ui.error('Service name required')
 
-  var c = client(remote)
+  var c = client(remote, {key: opts.key})
   var unspin = ui.spin('Removing', id)
   c.remove(id, unspin)
 }

--- a/commands/restart.js
+++ b/commands/restart.js
@@ -5,7 +5,7 @@ var logStream = require('../lib/log-stream')
 module.exports = function (remote, id, opts) {
   if (!id) return ui.error('Service name required')
 
-  var c = client(remote)
+  var c = client(remote, {key: opts.key})
   var out
 
   var onsync = function () {

--- a/commands/services.js
+++ b/commands/services.js
@@ -7,7 +7,7 @@ module.exports = function (remote, id, opts) {
     return info(remote, id, opts)
   }
 
-  var connection = client(remote)
+  var connection = client(remote, {key: opts.key})
   connection.list(function (err, services) {
     if (err) return ui.error(err)
 

--- a/commands/start.js
+++ b/commands/start.js
@@ -5,7 +5,7 @@ var logStream = require('../lib/log-stream')
 module.exports = function (remote, id, opts) {
   if (!id) return ui.error('Service name required')
 
-  var c = client(remote)
+  var c = client(remote, {key: opts.key})
   var out
 
   if (opts.log !== false) {

--- a/commands/status.js
+++ b/commands/status.js
@@ -2,7 +2,7 @@ var client = require('../')
 var ui = require('../lib/ui')
 
 module.exports = function (remote, id, opts) {
-  var c = client(remote)
+  var c = client(remote, {key: opts.key})
 
   var filter = function (proc) {
     return !id || proc.id === id

--- a/commands/stop.js
+++ b/commands/stop.js
@@ -4,7 +4,7 @@ var ui = require('../lib/ui')
 module.exports = function (remote, id, opts) {
   if (!id) return ui.error('Service name required')
 
-  var c = client(remote)
+  var c = client(remote, {key: opts.key})
   var unspin = ui.spin('Stopping', id)
   c.stop(id, unspin)
 }

--- a/commands/sync.js
+++ b/commands/sync.js
@@ -4,7 +4,7 @@ var ui = require('../lib/ui')
 module.exports = function (remote, id, opts) {
   if (!id) return ui.error('Service name required')
 
-  var c = client(remote)
+  var c = client(remote, {key: opts.key})
   var unspin = ui.spin('Syncing', id)
   c.sync(id, function (err) {
     unspin(err)

--- a/commands/tarball.js
+++ b/commands/tarball.js
@@ -5,7 +5,7 @@ var fs = require('fs')
 module.exports = function (remote, id, opts) {
   if (!id) return ui.error('Service name required')
 
-  var c = client(remote)
+  var c = client(remote, {key: opts.key})
   var tar = c.tarball(id)
 
   tar.on('error', function (err) {

--- a/commands/update.js
+++ b/commands/update.js
@@ -20,7 +20,7 @@ module.exports = function (remote, id, opts) {
   if (!id) return ui.error('Service name required')
   if (!opts.force && undef(opts.env, opts.tag, opts.untag, opts.start, opts.limit, opts.build)) return ui.error(help)
 
-  var c = client(remote)
+  var c = client(remote, {key: opts.key})
   var unspin = ui.spin('Updating', id)
   var untags = [].concat(opts.untag || [])
 


### PR DESCRIPTION
With this, all the commands can use the --key option (before it could only be used with the `remotes` command). With this PR you can do stuff like this

`hms deploy root@example.com main-website --key /path/to/private/key`
